### PR TITLE
Slight tweaks and added link to Chunky 2.2

### DIFF
--- a/docs/download.md
+++ b/docs/download.md
@@ -6,7 +6,7 @@ Download options for [version @VERSION@][1]:
 * [Windows Installer][2]
 * [Mac Bundle](@DMG_DL_LINK@)
 * [Cross-platform binaries (Mac, Win, Linux)][3]
-* [Launcher only (Mac, Win, Linux)][4]
+* [Launcher only (Mac, Win, Linux)][4] --- RECOMMENDED
 
 Mac bundles are only tested with the Oracle Java distribution, and may not work
 on all systems.

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,10 @@
 Chunky is a Minecraft mapping and rendering tool.  Check out [the gallery][15]
 for examples of what Chunky can do!
 
-<a href="/download.html" class="button">Download version @VERSION@</a>
+## Downloads
+---
+<a href="/download.html" class="button">Chunky @VERSION@ (upto mc1.12)</a> <a href="https://chunky.lemaik.de/" class="button">Chunky 2.2 (mc1.13+)</a>
+---
 
 New users are recommended to look at the [Installation Instructions][13] and
 the [Getting Started Guide][14], or for a full guide check [Your First Render!](./your_first_render.html)
@@ -12,10 +15,12 @@ For help and development updates, join our Discord:
 
 [![Join our Discord server!](discord_icon.png)](https://discord.gg/VqcHpsF)
 
-## Chunky 2.0
+## Chunky for Minecraft 1.13+
 
-Chunky 1.4.X only supports Minecraft 1.12 and earlier. For Minecraft 1.13 and beyond, we are developing
-Chunky 2.0. [Read more here.](/chunky2.html)
+Chunky 1.4.X only supports Minecraft 1.12 and earlier. For Minecraft 1.13 there is
+Chunky 2.0, [Read more here.](/chunky2.html), however this is incomplete - For full Minecraft 1.13+ support, including 1.16, [please see leMaik's site on Chunky 2.2](https://chunky.lemaik.de/).
+
+---
 
 ## Frequently Asked Questions
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,8 +12,8 @@ btnsub{
 }
 .button{
   font-size:25px;
-  line-height: 20px
-  padding-top:0.6rem;
+  line-height: 20px;
+  padding-top:0.8rem;
   padding-bottom:0.6rem;
   padding-right:2rem;
   padding-left:2rem;

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,25 @@ Chunky is a Minecraft mapping and rendering tool.  Check out [the gallery][15]
 for examples of what Chunky can do!
 
 ## Downloads
----
-<a href="/download.html" class="button">Chunky @VERSION@ (upto mc1.12)</a> <a href="https://chunky.lemaik.de/" class="button">Chunky 2.2 (mc1.13+)</a>
----
+<style>
+btnsub{
+  font-size:13px;
+  line-height:5px;
+  color:#e6e6e6;
+}
+.button{
+  font-size:25px;
+  line-height: 20px
+  padding-top:0.6rem;
+  padding-bottom:0.6rem;
+  padding-right:2rem;
+  padding-left:2rem;
+}
+</style>
+<center>
+	<a href="/download.html" class="button"> Chunky @VERSION@ <br><btnsub>Minecraft 1.12 or older</btnsub></a>
+	<a href="https://chunky.lemaik.de/" class="button"> Chunky 2.2.0 <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
+</center>
 
 New users are recommended to look at the [Installation Instructions][13] and
 the [Getting Started Guide][14], or for a full guide check [Your First Render!](./your_first_render.html)
@@ -18,7 +34,7 @@ For help and development updates, join our Discord:
 ## Chunky for Minecraft 1.13+
 
 Chunky 1.4.X only supports Minecraft 1.12 and earlier. For Minecraft 1.13 there is
-Chunky 2.0, [Read more here.](/chunky2.html), however this is incomplete - For full Minecraft 1.13+ support, including 1.16, [please see leMaik's site on Chunky 2.2](https://chunky.lemaik.de/).
+Chunky 2.0, [Read more here](/chunky2.html), however this is incomplete. For full Minecraft 1.13+ support, including 1.16, [please see leMaik's site on Chunky 2.2](https://chunky.lemaik.de/).
 
 ---
 

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -75,7 +75,9 @@ if "%ERRORLEVEL%"=="0" goto mainEnd
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
+pause
 if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
+pause
 exit /b 1
 
 :mainEnd

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -75,9 +75,7 @@ if "%ERRORLEVEL%"=="0" goto mainEnd
 :fail
 rem Set variable GRADLE_EXIT_CONSOLE if you need the _script_ return code instead of
 rem the _cmd.exe /c_ return code!
-pause
 if  not "" == "%GRADLE_EXIT_CONSOLE%" exit 1
-pause
 exit /b 1
 
 :mainEnd

--- a/tools/mdwrapper.py
+++ b/tools/mdwrapper.py
@@ -9,7 +9,7 @@ if len(sys.argv) > 1 and sys.argv[1] == 'prepare':
     with codecs.open('misc/menu.md', mode='r', encoding='utf-8') as f:
         menu = f.read()
     with codecs.open('tmp/menu-template.html', mode='w', encoding='utf-8') as f:
-        f.write(markdown.markdown(menu, ['extra']))
+        f.write(markdown.markdown(menu, extensions=['extra']))
     sys.exit(0)
 
 if len(sys.argv) > 1:
@@ -68,7 +68,7 @@ sys.stdout.write("""
       <!--Content goes here -->
       <td id="article">
 """)
-sys.stdout.write(markdown.markdown(text, ['extra']))
+sys.stdout.write(markdown.markdown(text, extensions=['extra']))
 sys.stdout.write("""
       <div id="footer"><a href="https://github.com/llbit/chunky-docs/edit/master/docs/%s">Edit page</a></div>
       </td>


### PR DESCRIPTION
Goal: Inform people using a search engine to reach the Chunky website of the existence of Chunky 2.2. Avoid issues where people download the 1.4.5 installer and cannot access the update site option.

- Fixed mdwrapper.py to run on modern installs.
- Added a few pauses to gradlew.bat so failures can be debugged easier.
- Tweaked index.md to include a button to Chunky 2.2 along with a description of different versions (tweak Chunky 2.0 section). Using an inline style sheet here just in case buttons are used elsewhere.
- Added a `Recommended` tag next to launcher download -- Hopefully will help in avoiding people downloading the installer which cannot obtain Chunky 2.X.