### PR TITLE
Updates for Release 2.3.0 and minor fixes and improvements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ task copyDocs(type: Copy) {
 		DMG_DL_LINK: "${version['dmg.dl.link']}".toString(),
 		ZIP_DL_LINK: "${version['zip.dl.link']}".toString(),
 		BUILD_DATE: "${version['build.date']}".toString(),
+		MODERN_VERSION: "${version['modern.version']}".toString(),
 	])
 }
 

--- a/docs/chunky2.md
+++ b/docs/chunky2.md
@@ -42,6 +42,4 @@ btnsub{
 * Pre-1.13 chunks are not loaded (shown with an error icon in the 2D map).
 * Minecraft 1.13 worlds can contain pre-1.13 chunks and need to be converted
   for Chunky 2.2 to load them.
-* Biome colors do not affect water color in Chunky. Set a custom water color
-  under the Water settings tab or load a 1.12 resource pack.
-
+	NOTE - Worlds made with Spigot, or similar, may not convert automatically and would require manual exploration to function correctly.

--- a/docs/chunky2.md
+++ b/docs/chunky2.md
@@ -23,9 +23,9 @@ btnsub{
 }
 </style>
 <center>
-	<a href="https://chunky.lemaik.de/" class="button"> Chunky 2.2.0 <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
+	<a href="https://chunky.lemaik.de/" class="button"> Chunky @MODERN_VERSION@ <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
 </center>
-![Chunky 2.2 preview](chunky2preview.png)
+![Chunky 2 preview](chunky2preview.png)
 
 ## Features
 
@@ -41,5 +41,5 @@ btnsub{
 * Rendering speed is lower overall and in particular with water.
 * Pre-1.13 chunks are not loaded (shown with an error icon in the 2D map).
 * Minecraft 1.13 worlds can contain pre-1.13 chunks and need to be converted
-  for Chunky 2.2 to load them.
+  for Chunky 2 to load them.
 	NOTE - Worlds made with Spigot, or similar, may not convert automatically and would require manual exploration to function correctly.

--- a/docs/download.md
+++ b/docs/download.md
@@ -22,6 +22,7 @@ See Also
 * [Installation instructions][5]
 * [Getting started guide][6]
 * [Snapshots][7]
+* [Chunky 1.4.5 for Minecraft upto 1.12][8]
 
 [1]: release/@VERSION@/release_notes.html
 [2]: @EXE_DL_LINK@
@@ -30,3 +31,4 @@ See Also
 [5]: install.html
 [6]: getting_started.html
 [7]: /snapshot.html
+[8]: release/1.4.5/release_notes.html

--- a/docs/download.md
+++ b/docs/download.md
@@ -22,7 +22,7 @@ See Also
 * [Installation instructions][5]
 * [Getting started guide][6]
 * [Snapshots][7]
-* [Chunky 1.4.5 for Minecraft upto 1.12][8]
+* [Chunky 2.3.0 release notes][8]
 
 [1]: release/@VERSION@/release_notes.html
 [2]: @EXE_DL_LINK@
@@ -31,4 +31,4 @@ See Also
 [5]: install.html
 [6]: getting_started.html
 [7]: /snapshot.html
-[8]: release/1.4.5/release_notes.html
+[8]: release/2.3.0/release_notes.html

--- a/docs/download.md
+++ b/docs/download.md
@@ -13,7 +13,7 @@
 Download Chunky
 ===============
 
-Download options for [version 2.3.0][1] for Minecraft 1.13+:
+Download options for [version @MODERN_VERSION@][1] for Minecraft 1.13+:
 
 * [Chunky Launcher (Mac, Win, Linux)][4]
 
@@ -21,7 +21,7 @@ Download options for [version 2.3.0][1] for Minecraft 1.13+:
 Release Notes
 -------------
 
-[Click here to go to the release notes][1] for version 2.3.0.
+[Click here to go to the release notes][1] for version @MODERN_VERSION@.
 
 
 See Also
@@ -30,10 +30,10 @@ See Also
 * [Installation instructions][5]
 * [Getting started guide][6]
 * [Snapshots][7]
-* [Chunky 1.4.5 for Minecraft 1.12 or older][8]
+* [Chunky @VERSION@ for Minecraft 1.12 or older][8]
 
 <div class="warning">
-  <strong>Using Minecraft 1.12 or older?</strong> Chunky 2.X only supports Minecraft 1.13 or later. For Minecraft 1.12 or older you need to download <a href="/release/1.4.5/release_notes.html">Chunky 1.4.5</a>.
+  <strong>Using Minecraft 1.12 or older?</strong> Chunky 2.X only supports Minecraft 1.13 or later. For Minecraft 1.12 or older you need to download <a href="/release/1.4.5/release_notes.html">Chunky @VERSION@</a>.
 </div>
 
 [1]: release/2.3.0/release_notes.html

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,3 +1,6 @@
+Download Chunky
+===============
+
 <style>
 .warning {
   padding: 20px;
@@ -9,9 +12,6 @@
   border-left: 5px solid #bd5634;
 }
 </style>
-
-Download Chunky
-===============
 
 Download options for [version @MODERN_VERSION@][1] for Minecraft 1.13+:
 
@@ -27,6 +27,7 @@ Release Notes
 See Also
 --------
 
+* [jackjt8's Guide to Chunky][9]
 * [Installation instructions][5]
 * [Getting started guide][6]
 * [Snapshots][7]
@@ -34,6 +35,7 @@ See Also
 
 <div class="warning">
   <strong>Using Minecraft 1.12 or older?</strong> Chunky 2.X only supports Minecraft 1.13 or later. For Minecraft 1.12 or older you need to download <a href="/release/1.4.5/release_notes.html">Chunky @VERSION@</a>.
+  </strong>
 </div>
 
 [1]: release/2.3.0/release_notes.html
@@ -44,3 +46,4 @@ See Also
 [6]: getting_started.html
 [7]: /snapshot.html
 [8]: release/1.4.5/release_notes.html
+[9]: https://jackjt8.github.io/ChunkyGuide/

--- a/docs/download.md
+++ b/docs/download.md
@@ -1,20 +1,28 @@
+<style>
+.warning {
+  padding: 20px;
+  background-color: #3e475b;
+  color: white;
+  opacity: 1;
+  transition: opacity 0.6s;
+  margin-bottom: 15px;
+  border-left: 5px solid #bd5634;
+}
+</style>
+
 Download Chunky
 ===============
 
-Download options for [version @VERSION@][1]:
+Download options for [version 2.3.0][1] for Minecraft 1.13+:
 
-* [Windows Installer][2]
-* [Mac Bundle](@DMG_DL_LINK@)
-* [Cross-platform binaries (Mac, Win, Linux)][3]
-* [Launcher only (Mac, Win, Linux)][4] --- RECOMMENDED
+* [Chunky Launcher (Mac, Win, Linux)][4]
 
-Mac bundles are only tested with the Oracle Java distribution, and may not work
-on all systems.
 
 Release Notes
 -------------
 
-[Click here to go to the release notes][1] for version @VERSION@.
+[Click here to go to the release notes][1] for version 2.3.0.
+
 
 See Also
 --------
@@ -22,13 +30,17 @@ See Also
 * [Installation instructions][5]
 * [Getting started guide][6]
 * [Snapshots][7]
-* [Chunky 2.3.0 release notes][8]
+* [Chunky 1.4.5 for Minecraft 1.12 or older][8]
 
-[1]: release/@VERSION@/release_notes.html
+<div class="warning">
+  <strong>Using Minecraft 1.12 or older?</strong> Chunky 2.X only supports Minecraft 1.13 or later. For Minecraft 1.12 or older you need to download <a href="/release/1.4.5/release_notes.html">Chunky 1.4.5</a>.
+</div>
+
+[1]: release/2.3.0/release_notes.html
 [2]: @EXE_DL_LINK@
 [3]: @ZIP_DL_LINK@
-[4]: http://chunkyupdate2.llbit.se/ChunkyLauncher.jar
+[4]: https://chunkyupdate.lemaik.de/ChunkyLauncher.jar
 [5]: install.html
 [6]: getting_started.html
 [7]: /snapshot.html
-[8]: release/2.3.0/release_notes.html
+[8]: release/1.4.5/release_notes.html

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,6 +12,8 @@ Please post bugs on the [chunky GitHub page.][1]
   emitters under the Lighting tab in the Render Controls dialog to remove most
   of the random bright dots.  **Note that rendering for a longer time will
   eventually remove the noise**, though it may take a very long time.
+  
+	Note - There are techniques and plugins which can help reduce noise. For more information please visit [jackjt8's Guide to Chunky - Denoising][5].
 
 * **Q: How long does it take to render an image?**
   There is no exact answer to this question. The main thing that affects render
@@ -43,3 +45,4 @@ Please post bugs on the [chunky GitHub page.][1]
 [1]:https://github.com/llbit/chunky/issues
 [3]:/skymaps.html
 [4]:minecraft_compatibility.html
+[5]: https://jackjt8.github.io/ChunkyGuide/docs/advanced_techniques/denoising.html

--- a/docs/headless.md
+++ b/docs/headless.md
@@ -117,7 +117,8 @@ Command-Line Options
 Run Chunky with the `-help` command to see a list of all available command-line
 options. Currently these options are available:
 
-* `-render <SCENE>` - render in headless mode
+* `-render <SCENE>` - render in headless mode.
+	You may also need to add the `-f` flag to force a scene to render.
 * `-texture <FILE>` - load the specified texture pack
 * `-snapshot <SCENE> <PNG>` - create a snapshot from a scene
 * `-scene-dir <DIR>` - specify scene directory

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ btnsub{
 </style>
 <center>
 	<a href="/download.html" class="button"> Chunky @VERSION@ <br><btnsub>Minecraft 1.12 or older</btnsub></a>
-	<a href="https://chunky.lemaik.de/" class="button"> Chunky 2.2.0 <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
+	<a href="https://chunky.lemaik.de/" class="button"> Chunky 2.3.0 <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
 </center>
 
 New users are recommended to look at the [Installation Instructions][13] and
@@ -33,7 +33,7 @@ For help and development updates, join our Discord:
 
 ## Chunky for Minecraft 1.13+
 
-Chunky 1.4.X only supports Minecraft 1.12 and earlier. For full Minecraft 1.13+ support, including 1.16, [please see leMaik's site on Chunky 2.2](https://chunky.lemaik.de/).
+Chunky 1.4.X only supports Minecraft 1.12 and earlier. For full Minecraft 1.13+ support, including 1.16, [please see leMaik's site on Chunky 2.3.0](https://chunky.lemaik.de/).
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ btnsub{
 </style>
 <center>
 	<a href="/download.html" class="button"> Chunky @VERSION@ <br><btnsub>Minecraft 1.12 or older</btnsub></a>
-	<a href="https://chunky.lemaik.de/" class="button"> Chunky 2.3.0 <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
+	<a href="https://chunky.lemaik.de/" class="button"> Chunky @MODERN_VERSION@ <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
 </center>
 
 New users are recommended to look at the [Installation Instructions][13] and
@@ -33,7 +33,7 @@ For help and development updates, join our Discord:
 
 ## Chunky for Minecraft 1.13+
 
-Chunky 1.4.X only supports Minecraft 1.12 and earlier. For full Minecraft 1.13+ support, including 1.16, [please see leMaik's site on Chunky 2.3.0](https://chunky.lemaik.de/).
+Chunky 1.4.X only supports Minecraft 1.12 and earlier. For full Minecraft 1.13+ support, including Minecraft 1.16, [please see leMaik's site on Chunky @MODERN_VERSION@](https://chunky.lemaik.de/).
 
 ---
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -4,13 +4,14 @@ Installing Chunky
 Before installing Chunky you will need Java 8 update 40 or later.
 [You can download Java here.](http://java.com)
 
-On Ubuntu, and some other Linux distributions, you may have to install a JavaFX
+On Ubuntu, some other Linux distributions, and with Java 11 or greater you may have to install a JavaFX
 library to be able to run Chunky. On Ubuntu 16.04, just have to install the
-package `openjfx`.
+package `OpenJFX`.
 
 There are several different ways to install Chunky. If you are using Windows
 then the [Windows Installer](@EXE_DL_LINK@) is probably the best option.
 There is also a handy [Mac Bundle](@DMG_DL_LINK@) for Mac users.
+However to use Chunky 2.X you need to use the ChunkyLauncher.jar.
 
 For other platforms you can [download the Chunky Launcher
 (ChunkyLauncher.jar)](http://chunkyupdate.llbit.se/ChunkyLauncher.jar). The
@@ -20,7 +21,7 @@ command in a terminal/command prompt:
 
     java -jar ChunkyLauncher.jar
 
-On later versions of OpenJDK Java, you might need to run it with something like this:
+On later versions of OpenJDK Java, you might need to run it with `--module-path` & `--add-modules` like below:
 
     java --module-path /usr/lib/jvm/java-11-openjdk/lib/ --add-modules javafx.controls,javafx.fxml -jar ChunkyLauncher.jar
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,7 +6,7 @@ Before installing Chunky you will need Java 8 update 40 or later.
 
 On Ubuntu, some other Linux distributions, and with Java 11 or greater you may have to install a JavaFX
 library to be able to run Chunky. On Ubuntu 16.04, just have to install the
-package `OpenJFX`.
+package `openjfx` (ie apt-get install openjfx).
 
 There are several different ways to install Chunky. If you are using Windows
 then the [Windows Installer](@EXE_DL_LINK@) is probably the best option.
@@ -21,7 +21,7 @@ command in a terminal/command prompt:
 
     java -jar ChunkyLauncher.jar
 
-On later versions of OpenJDK Java, you might need to run it with `--module-path` & `--add-modules` like below:
+On later versions of OpenJDK Java, you might need to run it with `--module-path` and `--add-modules` like below:
 
     java --module-path /usr/lib/jvm/java-11-openjdk/lib/ --add-modules javafx.controls,javafx.fxml -jar ChunkyLauncher.jar
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,6 +1,23 @@
 Installing Chunky
 =================
 
+<style>
+.warning {
+  padding: 20px;
+  background-color: #3e475b;
+  color: white;
+  opacity: 1;
+  transition: opacity 0.6s;
+  margin-bottom: 15px;
+  border-left: 5px solid #bd5634;
+}
+</style>
+
+<div class="warning">
+  <strong> If you are looking for installation instructions for Chunky 2.X+ please refer to <a href="https://jackjt8.github.io/ChunkyGuide/docs/setup/installation.html">jackjt8's Guide to Chunky - Installation</a>
+  </strong>
+</div>
+
 Before installing Chunky you will need Java 8 update 40 or later.
 [You can download Java here.](http://java.com)
 

--- a/docs/release/2.3.0/release_notes.md
+++ b/docs/release/2.3.0/release_notes.md
@@ -1,0 +1,71 @@
+Chunky 2.3.0
+============
+
+## Downloads
+
+* [Chunky Launcher v1.12.0 (win, mac, linux)](https://chunkyupdate.lemaik.de/ChunkyLauncher.jar)
+
+## Release Notes
+
+Add emitter sampling for faster convergence and less emitter noise.
+
+Add support for player head blocks with custom skins.
+
+Render the books on lecterns and enchanting tables and make them poseable in the entities panel.
+
+Fix jello water caused by interaction between water plane and normal water.
+
+Add biome-based water color.
+
+Performance and memory usage improvements.
+
+
+## ChangeLog
+
+### New Features
+* Add emitter sampling for faster convergence and less emitter noise
+* Add support for player head blocks with custom skins
+* Render the books on lecterns
+* Render the books on enchanting tables and allow posing them
+* Add new 1.16 jigsaw block orientations
+* Add a new big packed octree for very large scenes and a selector for the octree implementation; plugins can now add custom octrees
+* Add rule of thirds guides
+* Add support for exporting rendered images in PFM format
+
+### Improvements
+* Allow changing the output format in the “Save current frame” dialog
+* Improve alpha computation performance
+* Make fog work underwater
+* Make the fog slider logarithmic
+* Update the chain model for 1.16.2-pre1
+* Refactor chunk textures and water normal map to reduce memory usage
+* Improve octree optimization and scene loading
+* Add a selector for the octree implementation
+* Show a confirm dialog when trying to overwrite an existing scene
+* Save scenes in per-scene directories (old scenes can still be loaded)
+* Update biome names and grass/foliage colors
+* Improve biome colors in the 2d map
+* Optimize the octree size
+* Reduce memory usage of textures (especially when using high-resolution resourcepacks)
+
+### Bug Fixes
+* Fix rendering deadlock caused by cloud intersections
+* Fix jello water caused by interaction between water plane and normal water
+* Fix water block below vines
+* Fix player helmet rotation
+* Fix selection rectangle alignment in the 2d map view
+* Fix Chunky not exiting in headless mode
+* Fix scene zip export
+* Fix camera tab not updating when moving the camera in the 2d map view
+* Fix loading of (partially) corrupted chunks, should * Fix loading spigot/papercraft worlds
+* Fix tall flowers in the materials tab
+* Fix position of skulls attached to walls
+* Fix missing texture for turtle helmet
+* Fix hat and helmet sizes not matching the ingame sizes
+* Fix some headless mode options not working
+* Fix campfire rendering bug (flame clipping)
+* Fix render not being reset when the ray depth is changed
+* Disable the load chunks button if no world is loaded
+* Fix not being able to load some 1.16 chunks
+* Fix spruce and birch leaves and lily pads color
+* Fix wrong render time when rendering a scene that was rendered before but that doesn't have the dump anymore

--- a/docs/release/2.3.0/release_notes.md
+++ b/docs/release/2.3.0/release_notes.md
@@ -33,7 +33,7 @@ Performance and memory usage improvements.
 * Add support for exporting rendered images in PFM format
 
 ### Improvements
-* Allow changing the output format in the “Save current frame” dialog
+* Allow changing the output format in the Save current frame dialog
 * Improve alpha computation performance
 * Make fog work underwater
 * Make the fog slider logarithmic
@@ -57,7 +57,8 @@ Performance and memory usage improvements.
 * Fix Chunky not exiting in headless mode
 * Fix scene zip export
 * Fix camera tab not updating when moving the camera in the 2d map view
-* Fix loading of (partially) corrupted chunks, should * Fix loading spigot/papercraft worlds
+* Fix loading of (partially) corrupted chunks, should
+* Fix loading spigot/papercraft worlds
 * Fix tall flowers in the materials tab
 * Fix position of skulls attached to walls
 * Fix missing texture for turtle helmet

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -13,6 +13,7 @@ General Render Tips
   process. When the image starts to get finished gamma correction can be
   re-enabled again without losing progress.  Also, hide the [Render Preview
   Window][1] during renders to speed up overall render time.
+	This issue is mostly fixed as of Chunky 2.3.0.
 * Increase the Ray Depth if you have a scene with many transparent or shiny
   blocks.
 * The rendering technique used in Chunky (Path Tracing) is very CPU intensive.

--- a/docs/your_first_render.md
+++ b/docs/your_first_render.md
@@ -18,6 +18,8 @@ Linux: Open the extracted folder, right click anywhere in the file browser windo
 Run: ```
 java -jar chunky-1.4.5.jar```, making sure to replace 1.4.5 with the correct version number.
 
+Or for later versions of Chunky: ```java -jar chunkylauncher.jar```
+
 ___
 ## Install and Launch
 

--- a/version.properties
+++ b/version.properties
@@ -2,3 +2,4 @@ version=1.4.5
 exe.dl.link=https://launchpad.net/chunky/1.4/1.4.5/+download/Chunky-1.4.5.exe
 dmg.dl.link=https://launchpad.net/chunky/1.4/1.4.5/+download/Chunky-1.4.5.dmg
 zip.dl.link=https://launchpad.net/chunky/1.4/1.4.5/+download/Chunky-1.4.5.zip
+modern.version=2.3.0


### PR DESCRIPTION
(Please squash the commit before PR)

- 2.2.0 -> 2.3.0
- Switched Downloads page to show Chunky 2.3.0 + added changelog; Banner + Link to Chunky 1.4.5 if using mc1.12 or older.
- Instructions for launching ChunkyLauncher.jar, JavaFX, etc.
- Updated known Chunky2 bugs
- Mentioned the -f flag for headless rendering as it was previously missing.