### PR TITLE
Changelogupdate

### DIFF
--- a/docs/chunky2.md
+++ b/docs/chunky2.md
@@ -8,7 +8,7 @@ scenes created with Chunky 1.4.X.
 To get the latest release please follow the button/link below.
 
 <center>
-	<a href="https://chunky.lemaik.de/" class="button"> Chunky @MODERN_VERSION@ <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
+	<a href="/download.html" class="button"> Chunky @MODERN_VERSION@ <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
 </center>
 ![Chunky 2 preview](chunky2preview.png)
 

--- a/docs/credits.md
+++ b/docs/credits.md
@@ -13,6 +13,8 @@ respective earliest contribution:
 * AEnterprise
 * Austin Bonander
 
+For a full list of code contributions please visit the [Contributors](https://github.com/chunky-dev/chunky/graphs/contributors) Insight page on GitHub.
+
 Wiki Editors
 ------------
 
@@ -21,6 +23,8 @@ Wiki Editors
 * Theudas
 * DaedalusYoung
 * EmeraldSnorlax
+
+For a full list of contributors to the wiki, chunky-docs, please visit the [Contribtuors](https://github.com/llbit/chunky-docs/graphs/contributors) Insight page on GitHub.
 
 Special Thanks
 --------------
@@ -38,9 +42,8 @@ Libraries Used
 Chunky uses the following libraries:
 
 * Apache Commons Math
-* JOCL
-* MWC64X
 * Markdown
+* fastutil
 
 These libraries are also listed with copyright notices in the legal part of the
 README file that ships with Chunky.

--- a/docs/download.md
+++ b/docs/download.md
@@ -9,7 +9,9 @@ Download options for [version @MODERN_VERSION@][1] for Minecraft 1.13+:
 Release Notes
 -------------
 
-[Click here to go to the release notes][1] for version @MODERN_VERSION@.
+[Click here to go to the release highlights][1] for version @MODERN_VERSION@.
+
+[See the release notes on Github](https://github.com/chunky-dev/chunky/releases/tag/@MODERN_VERSION@)
 
 
 See Also

--- a/docs/download.md
+++ b/docs/download.md
@@ -9,10 +9,21 @@ Download options for [version @MODERN_VERSION@][1] for Minecraft 1.13+:
 Release Notes
 -------------
 
-[Click here to go to the release highlights][1] for version @MODERN_VERSION@.
+[Click here to see the release notes](https://github.com/chunky-dev/chunky/releases/tag/@MODERN_VERSION@) for version @MODERN_VERSION@.
 
-[See the release notes on Github](https://github.com/chunky-dev/chunky/releases/tag/@MODERN_VERSION@)
+### Highlights
 
+* Add emitter sampling for faster convergence and less emitter noise.
+
+* Add support for player head blocks with custom skins.
+
+* Render the books on lecterns and enchanting tables and make them poseable in the entities panel.
+
+* Fix jello water caused by interaction between water plane and normal water.
+
+* Add biome-based water color.
+
+* Performance and memory usage improvements.
 
 See Also
 --------

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -23,7 +23,7 @@ Please post bugs on the [chunky GitHub page.][1]
   emitters, enable ESS, or use a denoising technique to speed up the convergence rate. See the [Path Tracing](/path_tracing.html) article or [jackjt8's Guide to Chunky - Denoising][5] for more details.
 
 * **Q: Is GPU rendering supported?**
-  GPU rendering support for Chunky 2.3 is currently in development in the form of an OpenCL 1.2 renderer plugin. This renderer is still under development and many features of the CPU renderer are not yet supported. For more information and WIP builds please visit [the plugins GitHub][6].
+  GPU rendering support for Chunky 2.4.0-77 or later is currently in development in the form of an OpenCL 1.2 renderer plugin. This renderer is still under development and many features of the CPU renderer are not yet supported. For more information and WIP builds please visit [the plugins GitHub][6].
 
 * **Q: Why are mobs not rendered?**
   Chunky cannot currently render entities, with the exception of paintings. Entities are objects that are separate from the blocks that make up the Minecraft worlds, such as players, mobs, minecarts, projectiles, etc. Future support for rendering entities is planned, but there is no deadline for this feature yet, so stay tuned!

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -38,6 +38,9 @@ Please post bugs on the [chunky GitHub page.][1]
 
 * **Q: Where can I find Skymaps?**
   The [Skymap][3] page has some useful links for obtaining high quality skymaps.
+  
+* **Q: What about the SpigotMC Plugin?**
+  [Chunky (SpigotMC)](https://www.spigotmc.org/resources/chunky.81534/) is an unrelated project which has an unfortunate name collision. Said plugin is used to quickly pre-generate server chunks.
 
 
 [0]:http://www.reddit.com/r/chunky

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,19 +28,18 @@ For help and development updates, join our Discord:
   emitters under the Lighting tab in the Render Controls dialog to remove most
   of the random bright dots.  **Note that rendering for a longer time will
   eventually remove the noise**, though it may take a very long time.
+  
+	Note - There are techniques and plugins which can help reduce noise. For more information please visit [jackjt8's Guide to Chunky - Denoising][5].
 
 * **Q: How long does it take to render an image?**
   There is no exact answer to this question. The main thing that affects render
   time is your CPU, the size of the image, and the lighting conditions in the
   scene you are rendering. It can take anywhere from an hour to a couple of
-  days to render a nice image. You can reduce the size of the canvas or disable
-  emitters to speed up the convergence rate. See the [Path Tracing](/path_tracing.html) article for
-  more details.
+  days to render a nice image. You can reduce the size of the canvas, disable
+  emitters, enable ESS, or use a denoising technique to speed up the convergence rate. See the [Path Tracing](/path_tracing.html) article or [jackjt8's Guide to Chunky - Denoising][5] for more details.
 
 * **Q: Is GPU rendering supported?**
-  GPU support is not actively being worked on right now. GPU rendering *may* be
-  added in the future, and some partial progress has been made toward this goal
-  but there are very many hurdles before it is fully supported.
+  GPU rendering support for Chunky 2.3 is currently in development in the form of an OpenCL 1.2 renderer plugin. This renderer is still under development and many features of the CPU renderer are not yet supported. For more information and WIP builds please visit [the plugins GitHub][6].
 
 Question still not answered? [Check the FAQ page.][8]
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Chunky
 
-Chunky is a Minecraft mapping and rendering tool.  Check out [the gallery][15]
+Chunky is a Minecraft rendering tool that uses Path Tracing to create realistic images of your Minecraft worlds.  Check out [the gallery][15]
 for examples of what Chunky can do!
 
 ## Downloads

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,6 @@ For help and development updates, join our Discord:
 
 [![Join our Discord server!](discord_icon.png)](https://discord.gg/VqcHpsF)
 
-## Chunky for Minecraft 1.13+
-
-Chunky 1.4.X only supports Minecraft 1.12 and earlier. For full Minecraft 1.13+ support, including Minecraft 1.16, [please see leMaik's site on Chunky @MODERN_VERSION@](https://chunky.lemaik.de/).
-
 ---
 
 ## Frequently Asked Questions

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,7 @@ For help and development updates, join our Discord:
   emitters, enable ESS, or use a denoising technique to speed up the convergence rate. See the [Path Tracing](/path_tracing.html) article or [jackjt8's Guide to Chunky - Denoising][5] for more details.
 
 * **Q: Is GPU rendering supported?**
-  GPU rendering support for Chunky 2.3 is currently in development in the form of an OpenCL 1.2 renderer plugin. This renderer is still under development and many features of the CPU renderer are not yet supported. For more information and WIP builds please visit [the plugins GitHub][6].
+  GPU rendering support for Chunky 2.4.0-77 or later is currently in development in the form of an OpenCL 1.2 renderer plugin. This renderer is still under development and many features of the CPU renderer are not yet supported. For more information and WIP builds please visit [the plugins GitHub][6].
   
 * **Q: What about the SpigotMC Plugin?**
   [Chunky (SpigotMC)](https://www.spigotmc.org/resources/chunky.81534/) is an unrelated project which has an unfortunate name collision. Said plugin is used to quickly pre-generate server chunks.

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,8 @@ for examples of what Chunky can do!
 
 ## Downloads
 <center>
-	<a href="/download.html" class="button"> Chunky @VERSION@ <br><btnsub>Minecraft 1.12 or older</btnsub></a>
-	<a href="https://chunky.lemaik.de/" class="button"> Chunky @MODERN_VERSION@ <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
+	<a href="/release/@VERSION@/release_notes.html" class="button"> Chunky @VERSION@ <br><btnsub>Minecraft 1.12 or older</btnsub></a>
+	<a href="/download.html" class="button"> Chunky @MODERN_VERSION@ <br><btnsub>Minecraft 1.13 or newer</btnsub></a>
 </center>
 
 New users are recommended to look at the [Installation Instructions][13] and

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,9 @@ For help and development updates, join our Discord:
 
 * **Q: Is GPU rendering supported?**
   GPU rendering support for Chunky 2.3 is currently in development in the form of an OpenCL 1.2 renderer plugin. This renderer is still under development and many features of the CPU renderer are not yet supported. For more information and WIP builds please visit [the plugins GitHub][6].
+  
+* **Q: What about the SpigotMC Plugin?**
+  [Chunky (SpigotMC)](https://www.spigotmc.org/resources/chunky.81534/) is an unrelated project which has an unfortunate name collision. Said plugin is used to quickly pre-generate server chunks.
 
 Question still not answered? [Check the FAQ page.][8]
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -50,8 +50,8 @@ Chunky is free software and the source code is made available under the [GNU
 General Public License, version 3][16].  The source code is managed on
 [GitHub][9].
 
-Chunky is Copyright (c) 2010-2014, Jesper &Ouml;qvist. Additional contributors
-are listed in the relevant source files and [on the credits page][17].
+Chunky is Copyright (c) 2010-2021, Jesper &Ouml;qvist and [Chunky Contributors][18];
+these are also listed in the relevant source files and on the [Credits][17] page.
 Copyright notices for third-party libraries used in Chunky are listed in the
 README file.
 
@@ -73,3 +73,4 @@ README file.
 [15]: /gallery.html
 [16]: http://opensource.org/licenses/gpl-3.0.html
 [17]: /credits.html
+[18]: https://github.com/chunky-dev/chunky/graphs/contributors

--- a/docs/release/2.1.0/release_notes.md
+++ b/docs/release/2.1.0/release_notes.md
@@ -1,0 +1,62 @@
+Chunky 2.1.0
+============
+
+## Downloads
+
+* [Chunky Launcher v1.12.0 (win, mac, linux)](https://chunkyupdate.lemaik.de/ChunkyLauncher.jar)
+
+## Release Notes
+
+See the release notes of Github:
+
+[2.1.0-187](https://github.com/chunky-dev/chunky/releases/tag/2.1.0-187)
+
+[2.1.0-190](https://github.com/chunky-dev/chunky/releases/tag/2.1.0-190)
+
+[2.1.0-197](https://github.com/chunky-dev/chunky/releases/tag/2.1.0-197)
+
+[2.1.0-204](https://github.com/chunky-dev/chunky/releases/tag/2.1.0-204)
+
+[2.1.0-208](https://github.com/chunky-dev/chunky/releases/tag/2.1.0-208)
+
+[2.1.0-213](https://github.com/chunky-dev/chunky/releases/tag/2.1.0-213)
+
+[2.1.0](https://github.com/chunky-dev/chunky/releases/tag/2.1.0)
+
+## Changelog
+
+### New Features
+Add barrel and loom blocks
+Add support for new sign types
+Add cartography table, fletching table, smithing table, blast furnace and smoker
+Add sweet berry bush, cornflower, lily of the valley, wither rose and bamboo saplings
+Support potted variants of the new flower types
+Add honey, bee nest, beehive and honeycomb blocks
+Add the composter block
+Add cut sandstone slab and cut red sandstone slab
+Add bamboo and potted bamboo
+Add the stonecutter
+Add the grindstone
+Add the lectern
+Add the campfire
+Add lanterns
+Add dragon egg
+Add a button to copy the current frame to the clipboard
+Render cauldron water levels
+
+### Improvements
+Improve slime block rendering
+Append a timestamp to the default scene name to prevent overwriting scene files by accident
+Update the cauldron model
+
+### Bug Fixes
+Fix snow rendering
+Fix textures of smooth quartz blocks, slabs and stairs
+Fix slab textures
+Fix block below top slabs being rendered as stone
+Fix nether portal transparency
+Fix end stone brick stairs and stone stairs textures
+Fix the ACES tone map operator
+Fix jack-o-lantern not emitting light
+Fix actors not being loaded if the scene doesn't contain any other entities
+Fix blocks below fern being rendered as stone

--- a/docs/release/2.1.0/release_notes.md
+++ b/docs/release/2.1.0/release_notes.md
@@ -23,40 +23,8 @@ See the release notes on Github:
 
 [2.1.0](https://github.com/chunky-dev/chunky/releases/tag/2.1.0)
 
-## Changelog
+### Highlights
 
-### New Features
-Add barrel and loom blocks
-Add support for new sign types
-Add cartography table, fletching table, smithing table, blast furnace and smoker
-Add sweet berry bush, cornflower, lily of the valley, wither rose and bamboo saplings
-Support potted variants of the new flower types
-Add honey, bee nest, beehive and honeycomb blocks
-Add the composter block
-Add cut sandstone slab and cut red sandstone slab
-Add bamboo and potted bamboo
-Add the stonecutter
-Add the grindstone
-Add the lectern
-Add the campfire
-Add lanterns
-Add dragon egg
-Add a button to copy the current frame to the clipboard
-Render cauldron water levels
+Added support for 1.14 and 1.15 block rendering.
 
-### Improvements
-Improve slime block rendering
-Append a timestamp to the default scene name to prevent overwriting scene files by accident
-Update the cauldron model
-
-### Bug Fixes
-Fix snow rendering
-Fix textures of smooth quartz blocks, slabs and stairs
-Fix slab textures
-Fix block below top slabs being rendered as stone
-Fix nether portal transparency
-Fix end stone brick stairs and stone stairs textures
-Fix the ACES tone map operator
-Fix jack-o-lantern not emitting light
-Fix actors not being loaded if the scene doesn't contain any other entities
-Fix blocks below fern being rendered as stone
+Numerous bug fixes and improvements.

--- a/docs/release/2.1.0/release_notes.md
+++ b/docs/release/2.1.0/release_notes.md
@@ -7,7 +7,7 @@ Chunky 2.1.0
 
 ## Release Notes
 
-See the release notes of Github:
+See the release notes on Github:
 
 [2.1.0-187](https://github.com/chunky-dev/chunky/releases/tag/2.1.0-187)
 

--- a/docs/release/2.2.0/release_notes.md
+++ b/docs/release/2.2.0/release_notes.md
@@ -7,7 +7,7 @@ Chunky 2.2.0
 
 ## Release Notes
 
-[See the release notes of Github](https://github.com/chunky-dev/chunky/releases/tag/2.2.0)
+[See the release notes on Github](https://github.com/chunky-dev/chunky/releases/tag/2.2.0)
 
 ### Highlights
 

--- a/docs/release/2.2.0/release_notes.md
+++ b/docs/release/2.2.0/release_notes.md
@@ -1,0 +1,18 @@
+Chunky 2.2.0
+============
+
+## Downloads
+
+* [Chunky Launcher v1.12.0 (win, mac, linux)](https://chunkyupdate.lemaik.de/ChunkyLauncher.jar)
+
+## Release Notes
+
+[See the release notes of Github](https://github.com/chunky-dev/chunky/releases/tag/2.2.0)
+
+### Highlights
+
+Implement a more efficient octree (reduces memory consumption and improves rendering performance by up to 10%)
+
+Re-implement the Materials tab
+
+Make lit furnaces, smokers and blast furnaces emit light

--- a/docs/release/2.3.0/release_notes.md
+++ b/docs/release/2.3.0/release_notes.md
@@ -7,7 +7,7 @@ Chunky 2.3.0
 
 ## Release Notes
 
-[See the release notes of Github](https://github.com/chunky-dev/chunky/releases/tag/2.3.0)
+[See the release notes on Github](https://github.com/chunky-dev/chunky/releases/tag/2.3.0)
 
 ## Highlights
 

--- a/docs/release/2.3.0/release_notes.md
+++ b/docs/release/2.3.0/release_notes.md
@@ -7,6 +7,10 @@ Chunky 2.3.0
 
 ## Release Notes
 
+[See the release notes of Github](https://github.com/chunky-dev/chunky/releases/tag/2.3.0)
+
+## Highlights
+
 Add emitter sampling for faster convergence and less emitter noise.
 
 Add support for player head blocks with custom skins.
@@ -18,55 +22,3 @@ Fix jello water caused by interaction between water plane and normal water.
 Add biome-based water color.
 
 Performance and memory usage improvements.
-
-
-## ChangeLog
-
-### New Features
-* Add emitter sampling for faster convergence and less emitter noise
-* Add support for player head blocks with custom skins
-* Render the books on lecterns
-* Render the books on enchanting tables and allow posing them
-* Add new 1.16 jigsaw block orientations
-* Add a new big packed octree for very large scenes and a selector for the octree implementation; plugins can now add custom octrees
-* Add rule of thirds guides
-* Add support for exporting rendered images in PFM format
-
-### Improvements
-* Allow changing the output format in the Save current frame dialog
-* Improve alpha computation performance
-* Make fog work underwater
-* Make the fog slider logarithmic
-* Update the chain model for 1.16.2-pre1
-* Refactor chunk textures and water normal map to reduce memory usage
-* Improve octree optimization and scene loading
-* Add a selector for the octree implementation
-* Show a confirm dialog when trying to overwrite an existing scene
-* Save scenes in per-scene directories (old scenes can still be loaded)
-* Update biome names and grass/foliage colors
-* Improve biome colors in the 2d map
-* Optimize the octree size
-* Reduce memory usage of textures (especially when using high-resolution resourcepacks)
-
-### Bug Fixes
-* Fix rendering deadlock caused by cloud intersections
-* Fix jello water caused by interaction between water plane and normal water
-* Fix water block below vines
-* Fix player helmet rotation
-* Fix selection rectangle alignment in the 2d map view
-* Fix Chunky not exiting in headless mode
-* Fix scene zip export
-* Fix camera tab not updating when moving the camera in the 2d map view
-* Fix loading of (partially) corrupted chunks, should
-* Fix loading spigot/papercraft worlds
-* Fix tall flowers in the materials tab
-* Fix position of skulls attached to walls
-* Fix missing texture for turtle helmet
-* Fix hat and helmet sizes not matching the ingame sizes
-* Fix some headless mode options not working
-* Fix campfire rendering bug (flame clipping)
-* Fix render not being reset when the ray depth is changed
-* Disable the load chunks button if no world is loaded
-* Fix not being able to load some 1.16 chunks
-* Fix spruce and birch leaves and lily pads color
-* Fix wrong render time when rendering a scene that was rendered before but that doesn't have the dump anymore

--- a/http-server.bat
+++ b/http-server.bat
@@ -1,0 +1,3 @@
+@ECHO OFF
+CD %~dp0\out
+http-server -o

--- a/misc/menu.md
+++ b/misc/menu.md
@@ -1,5 +1,5 @@
 * <a href="/search.html"><img src="/search.png">&nbsp;Search Documentation</a>
-* [![Join our Discord server!](discord_icon.png)](https://discord.gg/VqcHpsF)
+* [![Join our Discord server!](/discord_icon.png)](https://discord.gg/VqcHpsF)
 * [About](/index.html)
     * [News](/news.html)
     * [Download](/download.html)


### PR DESCRIPTION
- Update homepage Chunky description to match GitHub (removed mapping mention).
- Fixed download links & remove "in your face" links to `https://chunky.lemaik.de/`
- Removed redundant MC1.13+ section
- Update FAQs with clarification on the SpigotMC Plugin called Chunky
- Update Copyright + Credits
- Switch changelogs for 2.1+ over to GitHub release notes with just highlights being copied over
- Fixed Discord Image breaking when on any release page
- A random automation file that can be ignored
