### PR TITLE
Update skymap links

### DIFF
--- a/docs/skymaps.md
+++ b/docs/skymaps.md
@@ -40,7 +40,7 @@ samples available:
 
 * [CGSkies][2]
 * [openfootage.net][4]
-* [HDRMill][5]
+* [HDRI Haven][5]
 * [nordicFX][6]
 * [HDRI-Hub.com][7]
 * [sIBL Archive][8]
@@ -80,7 +80,7 @@ And this is what the resulting render should look like:
 [2]: http://www.cgskies.com/skies.php
 [3]: http://www.reddit.com/r/chunky/comments/17ts4b/some_more_skymaps/
 [4]: http://www.openfootage.net/?cat=15
-[5]: http://www.hdrmill.com/Freebies.htm
+[5]: https://hdrihaven.com/hdris/?c=skies
 [6]: http://www.nordicfx.net/?works=hdri
 [7]: http://www.hdri-hub.com/free-samples
 [8]: http://www.hdrlabs.com/sibl/archive.html

--- a/docs/skymaps.md
+++ b/docs/skymaps.md
@@ -25,7 +25,6 @@ Where to find skymaps
 
 These pages provide links to other pages, or downloads of non-HDR skymaps:
 
-* [http://www.wuala.com/Olson/Photos/Optikz_360_Skies/][1]
 * [http://www.reddit.com/r/chunky/comments/17ts4b/some_more_skymaps/][3]
 * [Milky Way Panorama by ESO][11]
 
@@ -77,7 +76,7 @@ And this is what the resulting render should look like:
 
 
 [0]: https://www.google.com/search?q=panoramic+sky+texture
-[1]: http://www.wuala.com/Olson/Photos/Optikz_360_Skies/
+
 [2]: http://www.cgskies.com/skies.php
 [3]: http://www.reddit.com/r/chunky/comments/17ts4b/some_more_skymaps/
 [4]: http://www.openfootage.net/?cat=15

--- a/docs/skymaps.md
+++ b/docs/skymaps.md
@@ -46,6 +46,7 @@ samples available:
 * [sIBL Archive][8]
 * [hdrmaps.com][9]
 * [Light probes by Bernhard Vogl][10]
+* [HDRI Skies][11]
 
 You can also try searcing Google for [Panoramic Sky Texture][0]
 
@@ -87,3 +88,4 @@ And this is what the resulting render should look like:
 [9]: http://hdrmaps.com/freebies
 [10]: http://dativ.at/lightprobes/
 [11]: https://www.eso.org/public/images/eso0932a/
+[12]: https://hdri-skies.com/

--- a/docs/skymaps.md
+++ b/docs/skymaps.md
@@ -45,7 +45,7 @@ samples available:
 * [sIBL Archive][8]
 * [hdrmaps.com][9]
 * [Light probes by Bernhard Vogl][10]
-* [HDRI Skies][11]
+* [HDRI Skies][12]
 
 You can also try searcing Google for [Panoramic Sky Texture][0]
 


### PR DESCRIPTION
Removed dead HDRMill link and replaced with HDRI Haven.